### PR TITLE
Speedup splitting field computation

### DIFF
--- a/henselization/sage/rings/padics/henselization/henselization.py
+++ b/henselization/sage/rings/padics/henselization/henselization.py
@@ -1403,6 +1403,7 @@ class HenselizationExtension(Henselization_base):
             base = base.base_ring()
         return ret
 
+    @cached_method
     def _repr_(self):
         r"""
         Return a printable representation of this ring.


### PR DESCRIPTION
surprisingly enough, _repr_ is quite expensive (100ms) as it needs to find a
description of the coefficients of defining polynomial of the field extension.
It gets called a lot as it is contained in some exception messages that are
expected in the control flow.